### PR TITLE
Handle token expiration and re-authenticate properly when needed

### DIFF
--- a/lowatt_grdf/api.py
+++ b/lowatt_grdf/api.py
@@ -90,7 +90,7 @@ class BaseAPI(metaclass=abc.ABCMeta):
 
     @property
     def access_token(self) -> str:
-        if self._access_token is None || self._access_expires < time.time():
+        if self._access_token is None or self._access_expires < time.time():
             self._access_token, self._access_expires = self._authenticate()
         return self._access_token
 

--- a/lowatt_grdf/api.py
+++ b/lowatt_grdf/api.py
@@ -93,7 +93,9 @@ class BaseAPI(metaclass=abc.ABCMeta):
 
     @property
     def access_token(self) -> str:
-        if self._access_token is None or self._access_expires < time.time():
+        if self._access_token is None or (
+            self._access_expires is not None and self._access_expires < time.time()
+        ):
             self._access_token, self._access_expires = self._authenticate()
         return self._access_token
 
@@ -114,7 +116,7 @@ class BaseAPI(metaclass=abc.ABCMeta):
         expires_in = data["expires_in"]
         assert isinstance(expires_in, int)
         access_expires = time.time() + expires_in
-        return [token, access_expires]
+        return (token, access_expires)
 
     def droits_acces(self, pce: Optional[list[str]] = None) -> Any:
         if not pce:

--- a/lowatt_grdf/api.py
+++ b/lowatt_grdf/api.py
@@ -94,7 +94,7 @@ class BaseAPI(metaclass=abc.ABCMeta):
             self._access_token, self._access_expires = self._authenticate()
         return self._access_token
 
-    def _authenticate(self) -> list[str]:
+    def _authenticate(self) -> tuple[str, float]:
         resp = requests.post(
             f"{OPENID_ENDPOINT}/access_token",
             data={

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -31,7 +31,10 @@ def grdf() -> api.API:
     responses.add(
         responses.POST,
         f"{api.OPENID_ENDPOINT}/access_token",
-        json={"access_token": "xxx"},
+        json={
+            "access_token": "xxx",
+            "expires_in": 14400,
+        },
     )
     return api.API("id", "secret")
 


### PR DESCRIPTION
In a long-living script that request data with the same API object, the token can come to expire (4h per default AFAIK).
This can lead to an exception where the next requests are rejected.

The suggested solution is rather simple:
* Read the provided expiration delay given by the access token request answer (`expires_in`);
* Calculate the datetime at which point it will be expired (`time.time() + expires_in`);
* Store it as a property of the API object (`BaseAPI._access_expires`);
* Check if that time is still in the future when requesting the token otherwise authenticate again.

This change affects `BaseAPI._authenticate()` signature, but as a private and quite reasonably used method, it does not seem to break any compatibility.