### PR TITLE
Fix Access model validation

### DIFF
--- a/lowatt_grdf/models.py
+++ b/lowatt_grdf/models.py
@@ -76,17 +76,23 @@ class Access(BaseModel):
     perim_donnees_publiees: bool
     perim_donnees_informatives: bool
     courriel_titulaire: str
-    raison_sociale_du_titulaire: Optional[str]
-    nom_titulaire: Optional[str]
     statut_controle_preuve: Optional[str]
     date_debut_droit_acces: str
     date_fin_droit_acces: str
     perim_donnees_conso_debut: str
     perim_donnees_conso_fin: str
+    raison_sociale_du_titulaire: Optional[str] = None
+    nom_titulaire: Optional[str] = None
     date_consentement_declaree: Optional[str] = None
     numero_telephone_titulaire: Optional[str] = None
     perim_donnees_contractuelles: bool = False
     perim_donnees_techniques: bool = False
+
+    def __attrs_post_init__(self) -> None:
+        if not self.raison_sociale_du_titulaire and not self.nom_titulaire:
+            raise ValueError(
+                "One of raison_sociale_du_titulaire or nom_titulaire is expected"
+            )
 
     def __str__(self) -> str:
         name = self.raison_sociale_du_titulaire or self.nom_titulaire

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -273,8 +273,9 @@ def test_check_constent_validation_preuve(
         headers={"Content-Type": "application/nd-json"},
         body=ndjson.dumps(payload),
     )
-    with caplog.at_level(logging.INFO, logger="lowatt.grdf"), pytest.raises(
-        RuntimeError, match="Theses consents have validation issues"
+    with (
+        caplog.at_level(logging.INFO, logger="lowatt.grdf"),
+        pytest.raises(RuntimeError, match="Theses consents have validation issues"),
     ):
         grdf.check_consent_validation()
     assert [r.message for r in caplog.records] == [

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -10,7 +10,6 @@ def test_structure_access() -> None:
             "date_debut_droit_acces": "2022-07-11",
             "date_fin_droit_acces": "2023-07-11",
             "statut_controle_preuve": None,
-            "nom_titulaire": None,
             "raison_sociale_du_titulaire": "COGIP",
             "courriel_titulaire": "cogip@example.com",
             "perim_donnees_informatives": "Vrai",


### PR DESCRIPTION
Seems raison_sociale_du_titulaire or nom_titulaire might not be present at all in returned document. So default them to None and add a validator to ensure one of raison_sociale_du_titulaire or nom_titulaire is set.