### PR TITLE
Add support for new auth endpoint to StagingAPI

### DIFF
--- a/lowatt_grdf/api.py
+++ b/lowatt_grdf/api.py
@@ -243,7 +243,9 @@ class StagingAPI(BaseAPI):
 
     @property
     def _auth_endpoint(self) -> str:
-        return OLD_AUTH_ENDPOINT
+        if self.client_id.startswith("grdf_"):
+            return OLD_AUTH_ENDPOINT
+        return NEW_AUTH_ENDPOINT
 
     def _parse_response(self, resp: requests.Response) -> Any:
         # XXX: Adjusts GRDF API responses to fit ndjson expected input because


### PR DESCRIPTION
The old auth endpoint doesn't work for me anymore for the staging API. The GRDF ADICT support team gave me new `client_id` and `client_secret` to be used with the new auth endpoint for the staging API. I am not sure if everyone is migrating at the same time so I kept a fallback to the old auth endpoint in case.